### PR TITLE
tx slot add to address

### DIFF
--- a/types/txn.go
+++ b/types/txn.go
@@ -19,10 +19,8 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/ledgerwatch/log/v3"
 	"hash"
 	"io"
 	"math/bits"
@@ -237,10 +235,6 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	// Next follows the destination address (if present)
 	dataPos, dataLen, err = rlp.String(payload, p)
 	slot.To = common.BytesToAddress(payload[dataPos : dataPos+dataLen])
-	log.Info(fmt.Sprintf("txRlp:%s", hex.EncodeToString(slot.Rlp)))
-	fmt.Printf(hex.EncodeToString(slot.Rlp))
-	log.Info(fmt.Sprintf("to:%s", slot.To.String()))
-	fmt.Printf(slot.To.String())
 	if err != nil {
 		return 0, fmt.Errorf("%w: to len: %s", ErrParseTxn, err) //nolint
 	}

--- a/types/txn.go
+++ b/types/txn.go
@@ -19,8 +19,10 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/ledgerwatch/log/v3"
 	"hash"
 	"io"
 	"math/bits"
@@ -99,6 +101,7 @@ type TxSlot struct {
 	Creation       bool     // Set to true if "To" field of the transaction is not set
 	Type           byte     // Transaction type
 	Size           uint32   // Size of the payload
+	To             common.Address
 }
 
 const (
@@ -233,6 +236,11 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	}
 	// Next follows the destination address (if present)
 	dataPos, dataLen, err = rlp.String(payload, p)
+	slot.To = common.BytesToAddress(payload[dataPos : dataPos+dataLen])
+	log.Info(fmt.Sprintf("txRlp:%s", hex.EncodeToString(slot.Rlp)))
+	fmt.Printf(hex.EncodeToString(slot.Rlp))
+	log.Info(fmt.Sprintf("to:%s", slot.To.String()))
+	fmt.Printf(slot.To.String())
 	if err != nil {
 		return 0, fmt.Errorf("%w: to len: %s", ErrParseTxn, err) //nolint
 	}


### PR DESCRIPTION
We may use the To address in erigon, and if we decode the slot.Rlp then it will cost unnecessary resource.
So it's better to cache the To address in slot, and can be used then.